### PR TITLE
feat(e04-t02): removed validation alerts and displayed register compo…

### DIFF
--- a/src/components/createblog/StepTwo.tsx
+++ b/src/components/createblog/StepTwo.tsx
@@ -1,26 +1,42 @@
 const StepTwo = ({
   setName,
   setDescription,
+  nameAlert,
+  descriptionAlert
 }: {
   setName: React.Dispatch<React.SetStateAction<string | null>>
   setDescription: React.Dispatch<React.SetStateAction<string | null>>
+  nameAlert: string | null
+  descriptionAlert: string | null
 }) => {
   return (
-    <section className="flex justify-center items-center flex-col w-full my-10">
+    <section className="flex justify-between items-center flex-row w-full my-10">
+
+      <aside className="w-1/5">
+<h1> Lorem ipsum dolor sit amet consectetur adipisicing elit. Animi blanditiis inventore expedita harum labore illum 
+  nostrum laboriosam debitis, quas non aperiam quis accusantium doloribus nihil magni saepe cupiditate assumenda voluptates? </h1>
+      </aside>
+      <aside className="w-3/5">
+
       <input
         type="text"
         placeholder="Nom de ton blog"
-        className="input input-bordered w-1/2 m-4 font-semibold text-lg focus:input-primary"
+        className="input input-bordered w-full m-4 font-semibold text-lg focus:input-primary"
         onChange={(e) => setName(e.target.value)}
-      />
-      {/* {errors.description && <span>Ce champ est requis</span>} */}
+        />
+      {nameAlert && 
+      <span className="text text-error m-4"> {nameAlert} </span>
+      }
       <input
         type="textarea"
         placeholder="Ajoute une courte description"
-        className="input input-bordered w-5/6 m-4 h-36 placeholder:text-justify px-8 py-4 focus:input-primary"
+        className="input input-bordered w-full m-4 h-36 placeholder:text-justify px-8 py-4 focus:input-primary"
         onChange={(e) => setDescription(e.target.value)}
-      />
-      {/* {errors.description && <span>Ce champ est requis</span>} */}
+        />
+        {descriptionAlert && 
+        <span className="text text-error m-4"> {descriptionAlert} </span>
+        }
+        </aside>
     </section>
   )
 }

--- a/src/routes/createblog.tsx
+++ b/src/routes/createblog.tsx
@@ -1,21 +1,25 @@
 import { useContext, useState, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { gql, useMutation } from '@apollo/client'
+
 import ProgressionBar from '../components/inputs/ProgressionBar'
-import Login from './login'
+import Register from './register'
 import StepThree from '../components/createblog/StepThree'
 import StepTwo from '../components/createblog/StepTwo'
 
 import { UserContext } from '../contexts/UserContext'
-import { blogSchema } from '../utils/blogValidation'
+import { nameValidation, descriptionValidation } from '../utils/blogValidation'
 
 const CreateBlog = () => {
   const [step, setStep] = useState<string>('first')
   const [name, setName] = useState<string | null>(null)
   const [description, setDescription] = useState<string | null>(null)
   const [template, setTemplate] = useState<number | null>(1)
-
+  const [nameAlert, setNameAlert] = useState<string | null>(null);
+  const [descriptionAlert, setDescriptionAlert] = useState<string | null>(null);
+  
   const { user, setIsCreatingBlog } = useContext(UserContext)
+
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -26,23 +30,38 @@ const CreateBlog = () => {
   }, [user])
 
   const validateBlog = () => {
-    let blogData = {
-      name,
-      description,
-    }
 
-    blogSchema
-      .validate(blogData)
+    let nameInput = {name};
+    let descriptionInput = {description};
+
+    nameValidation
+      .validate(nameInput)
       .then(() => {
-        setStep('third')
+        setNameAlert(null)
+        !descriptionAlert && setStep('third')
       })
       .catch((err: any) => {
-        // TODO Toaster qui affiche le message d'erreur
         const messages = err.errors
         messages.map((message: string) => {
-          alert(message)
+          setNameAlert(message)
         })
       })
+
+    descriptionValidation
+      .validate(descriptionInput)
+      .then(() => {
+        setDescriptionAlert(null)
+        !nameAlert && setStep('third')
+      })
+      .catch((err: any) => {
+        const messages = err.errors
+        messages.map((message: string) => {
+          setDescriptionAlert(message)
+        })
+      })
+    
+
+
   }
 
   const nextStep = () => {
@@ -102,20 +121,24 @@ const CreateBlog = () => {
       })
   }
 
+
   return (
-    <section className="min-h-screen flex justify-center items-center flex-col m-8 w-full">
+    <section className="min-h-screen max-w-screen flex justify-center items-center flex-col m-8">
+      <article className='flex justify-center items-center w-5/6 flex-col'>
+
       <ProgressionBar step={step}></ProgressionBar>
-      {step === 'first' ? <Login></Login> : null}
+
+      {step === 'first' ? <Register></Register> : null}
       {/* 
       Remplacer par le composant de login ou de register, et non la page entière */}
       {step === 'second' ? (
-        <StepTwo setName={setName} setDescription={setDescription}></StepTwo>
+        <StepTwo setName={setName} setDescription={setDescription} nameAlert={nameAlert} descriptionAlert={descriptionAlert}></StepTwo>
       ) : null}
       {step === 'third' ? (
         <StepThree setTemplate={setTemplate} template={template}></StepThree>
       ) : null}
 
-      <div className="group">
+      <div className="group flex w-full justify-end">
         {step === 'first' ? null : (
           <button className="btn btn-ghost" onClick={() => previousStep()}>
             Précédent
@@ -123,25 +146,26 @@ const CreateBlog = () => {
         )}
         {step === 'second' ? (
           <button
-            className="btn"
-            onClick={() => {
-              step === 'second' ? validateBlog() : nextStep()
-            }}
+          className="btn"
+          onClick={() => {
+            step === 'second' ? validateBlog() : nextStep()
+          }}
           >
             Etape suivante
           </button>
         ) : null}
         {step === 'third' ? (
           <div
-            className="btn"
-            onClick={() => {
-              template ? createNewBlog() : templateAlert()
-            }}
+          className="btn"
+          onClick={() => {
+            template ? createNewBlog() : templateAlert()
+          }}
           >
             Voir mon blog
           </div>
         ) : null}
       </div>
+        </article>
     </section>
   )
 }

--- a/src/routes/register.tsx
+++ b/src/routes/register.tsx
@@ -1,6 +1,8 @@
 import { gql, useMutation } from '@apollo/client'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
+import { useContext } from 'react'
+import { UserContext } from '../contexts/UserContext'
 import { FieldValues, useForm } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { RegisterFormProps } from '../components/inputs/inputsInterfaces'
@@ -25,6 +27,10 @@ const Register = () => {
 
   const [addUser] = useMutation(ADD_USER)
 
+  const { isCreatingBlog } = useContext(UserContext)
+
+  const navigate = useNavigate()
+
   const onSubmit = async (data: FieldValues) => {
     const user = {
       nickname: data.nickname,
@@ -34,6 +40,8 @@ const Register = () => {
     addUser({ variables: { ...user } })
       .then(() => {
         alert('Ok')
+        isCreatingBlog ? navigate('/login') : navigate('/')
+
       })
       .catch((err) => {
         console.error(err)

--- a/src/utils/blogValidation.ts
+++ b/src/utils/blogValidation.ts
@@ -8,7 +8,11 @@ yup.setLocale({
     min: 'Ton texte doit faire au moins ${min} caractères',
   },
 })
-export const blogSchema: any = yup.object().shape({
-  name: yup.string().required().min(5),
-  description: yup.string().required().min(10),
+
+export const nameValidation: any = yup.object().shape({
+  name: yup.string().nullable().required().min(5),
+})
+
+export const descriptionValidation: any = yup.object().shape({
+  description: yup.string().nullable().required().min(10),
 })


### PR DESCRIPTION
# TASK TO EPIC PR
(Delete if no relevant)

## The feature / The problem
Messages d'alerte hideux au moment de la validation des inputs

## What I've done / The solution
Modifié la page qui s'affiche en premier au step 1 : register au lieu de login, du coup ajout d'un navigate vers login pour se connecter directement après s'être enregistré
Quelques modifications de CSS pour les étapes de création de blog
Modification des alertes de validation pour le step 2

## Scope of my changes
page register
page CreateBlog
component StepTwo
utils/blogValidation

## Task
- [e04-t02:](link to issue)

## Type of change
- [x] New feature (feat)
- [ ] Fix issue (fix)
- [ ] Code refactorisation (refactor)
- [ ] Code testing (test)
- [ ] Add documentation (docs)


# Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my PR
- [ ] I have removed not needed logs
- [ ] I have remover TODO comments
- [ ] I have commented in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have been able to build my solution locally
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

# Communication
Something special like a warning about this PR