### PR TITLE
fix(staging): broken h6 rendering

### DIFF
--- a/src/utils/ouputContentBlocks.tsx
+++ b/src/utils/ouputContentBlocks.tsx
@@ -37,6 +37,12 @@ const outputData = (block: IContentBlock, index: number) => {
               {block.data.text}
             </h5>
           )
+        case 6:
+          return (
+            <h6 key={index} className="font-bold font-lobster mt-5">
+              {block.data.text}
+            </h6>
+          )
         default:
           throw new Error('Header level must be specified')
       }


### PR DESCRIPTION
Fix for Presentation Mardi !..

J'avais oublié qu'on autorisait les headers h6 dans l'éditeur.
La fonction outputBlocks s'arrêtait à 5 puis throw... 🤦 

T'is fixed 
🚀 