### PR TITLE
Fix/crash on new version save

### DIFF
--- a/src/components/editor/EditableArticle.tsx
+++ b/src/components/editor/EditableArticle.tsx
@@ -1,11 +1,4 @@
-import {
-  useContext,
-  useState,
-  useRef,
-  useCallback,
-  Dispatch,
-  SetStateAction,
-} from 'react'
+import { useContext, useState, useRef, useCallback } from 'react'
 import { useMutation, useQuery } from '@apollo/client'
 import type EditorJS from '@editorjs/editorjs'
 import { NotificationContext } from '../../contexts/NotificationContext'
@@ -47,6 +40,7 @@ const EditableArticle = ({
     articleCoverUrl || null
   )
   const [contentVersion, setContentVersion] = useState<number>(articleVersion)
+
   const [newContentVersion, setNewContentVersion] =
     useState<number>(articleVersion)
 

--- a/src/components/editor/EditableArticle.tsx
+++ b/src/components/editor/EditableArticle.tsx
@@ -53,7 +53,7 @@ const EditableArticle = ({
   const [updateArticle] = useMutation(UPDATE_ARTICLE)
   const [deleteArticle] = useMutation(DELETE_ARTICLE)
 
-  const { loading, error, data } = useQuery(GET_ONE_ARTICLE, {
+  const { loading, error, data, refetch } = useQuery(GET_ONE_ARTICLE, {
     variables: {
       allVersions: true,
       slug: articleSlug,
@@ -78,11 +78,7 @@ const EditableArticle = ({
           : contentVersion
 
       try {
-        const {
-          data: {
-            updateArticle: { slug },
-          },
-        } = await updateArticle({
+        await updateArticle({
           variables: {
             blogId,
             articleId,
@@ -144,10 +140,19 @@ const EditableArticle = ({
         }
       }
     }
-
     const dataToEdit = article.articleContent.filter(
       (content) => content.version === contentVersion
-    )[0].content.blocks
+    )
+
+    if (!dataToEdit.length) {
+      refetch({
+        allVersions: true,
+        slug: articleSlug,
+        blogSlug,
+      })
+      return <div>Chargement...</div>
+    }
+
     return (
       <>
         {!showTools ? (
@@ -193,7 +198,7 @@ const EditableArticle = ({
         </header>
         <div className="bg-white px-8 bg-opacity-80">
           <EditorWrapper
-            blocks={dataToEdit}
+            blocks={dataToEdit[0].content.blocks}
             handleInitialize={handleInitialize}
             editorCore={editorCore}
             uploadUrl={`/upload/blog/${blogId}/article/${articleId}`}

--- a/src/components/editor/EditorTools.tsx
+++ b/src/components/editor/EditorTools.tsx
@@ -1,7 +1,6 @@
 import { Dispatch, SetStateAction, useContext, useState } from 'react'
 import { IArticle } from '../../utils/interfaces/Interfaces'
 import ImageHandler from '../imagehandler/ImageHandler'
-import { TbEditCircle } from 'react-icons/tb'
 import { CgClose } from 'react-icons/cg'
 import { useMutation } from '@apollo/client'
 import {

--- a/src/components/editor/EditorWrapper.tsx
+++ b/src/components/editor/EditorWrapper.tsx
@@ -68,8 +68,8 @@ const EditorWrapper = ({
 
   useEffect(() => {
     const reloadEditor = async () => {
-      const isReady = await editorCore.current?.isReady
-      isReady && (await editorCore.current?.render({ blocks }))
+      await editorCore.current?.isReady
+      await editorCore.current?.render({ blocks })
     }
     if (editorCore.current !== null) {
       reloadEditor()

--- a/src/components/editor/EditorWrapper.tsx
+++ b/src/components/editor/EditorWrapper.tsx
@@ -68,8 +68,8 @@ const EditorWrapper = ({
 
   useEffect(() => {
     const reloadEditor = async () => {
-      await editorCore.current?.isReady
-      await editorCore.current?.render({ blocks })
+      const isReady = await editorCore.current?.isReady
+      isReady && (await editorCore.current?.render({ blocks }))
     }
     if (editorCore.current !== null) {
       reloadEditor()


### PR DESCRIPTION
another fix :
When creating new version of article content, page would crash for lack of new data in renderer.

Solution : force refresh query if contentVersion doesn't exist in Apollo Query.data